### PR TITLE
mtk: O: reintroduce atomic symbols

### DIFF
--- a/libcutils/Android.bp
+++ b/libcutils/Android.bp
@@ -56,6 +56,7 @@ cc_library {
     },
     host_supported: true,
     srcs: [
+        "atomic.c",
         "config_utils.c",
         "fs_config.cpp",
         "canned_fs_config.c",

--- a/libcutils/atomic.c
+++ b/libcutils/atomic.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define ANDROID_ATOMIC_INLINE
+
+#include <cutils/atomic.h>


### PR DESCRIPTION
Reintroduce atomic symbols in libcutils for old MTK  audio hals & Mali blobs
